### PR TITLE
feat: ユーザーデータのエクスポート/インポート機能をv2形式で追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,26 @@ $ sail npm run build
 ```shell
 $ sail artisan app:generate-missing-thumbnails # 強制再生成の場合 --overwrite
 ```
+
+## キューワーカー（バックグラウンドジョブ）
+
+エクスポート/インポート機能で必要です。
+
+起動
+```shell
+$ sail artisan queue:work
+```
+
+停止
+```shell
+# Ctrl+C
+```
+
+デーモンモード（常時起動）
+```shell
+$ sail artisan queue:work --daemon
+```
+
+> [!NOTE]
+> 開発中は別ターミナルで `sail artisan queue:work` を起動したままにしてください。
+> キューワーカーが動いていないと、エクスポート処理が完了しません。

--- a/app/Console/Commands/BackupCommand.php
+++ b/app/Console/Commands/BackupCommand.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+
+class BackupCommand extends Command
+{
+    protected $signature = 'app:backup {--output= : Output directory path (default: current directory)}';
+    protected $description = 'データベースと画像ファイルをバックアップする';
+
+    public function handle(): int
+    {
+        $outputDir = $this->option('output') ?: getcwd();
+
+        // ディレクトリ作成
+        if (!is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+
+        $timestamp = now()->format('Ymd_His');
+        $backupName = "hayonaos_backup_{$timestamp}";
+        $dbDumpPath = "{$outputDir}/{$backupName}.sql";
+        $archivePath = "{$outputDir}/{$backupName}.tar.gz";
+        $metadataPath = "{$outputDir}/{$backupName}_metadata.json";
+
+        $this->info('バックアップを開始します...');
+        $this->info("出力先: {$outputDir}");
+
+        // DB接続情報を取得
+        $connection = Config::get('database.default');
+        $dbConfig = Config::get("database.connections.{$connection}");
+        $host = $dbConfig['host'];
+        $port = $dbConfig['port'] ?? 3306;
+        $database = $dbConfig['database'];
+        $username = $dbConfig['username'];
+        $password = $dbConfig['password'];
+
+        // 1. データベースバックアップ
+        $this->line('');
+        $this->line('データベースをバックアップ中...');
+
+        $cmd = sprintf(
+            'mysqldump --host=%s --port=%d --user=%s --password=%s --default-character-set=utf8mb4 %s > %s',
+            escapeshellarg($host),
+            $port,
+            escapeshellarg($username),
+            escapeshellarg($password),
+            escapeshellarg($database),
+            escapeshellarg($dbDumpPath)
+        );
+
+        $output = [];
+        $returnCode = 0;
+        exec($cmd, $output, $returnCode);
+
+        if ($returnCode !== 0 || !file_exists($dbDumpPath) || filesize($dbDumpPath) === 0) {
+            $this->error('データベースのバックアップに失敗しました。');
+            return Command::FAILURE;
+        }
+
+        $this->info('✓ データベースバックアップ完了: ' . number_format(filesize($dbDumpPath)) . ' bytes');
+
+        // 2. 画像ファイルのアーカイブ作成
+        $publicPath = storage_path('app/public');
+        if (is_dir($publicPath)) {
+            $this->line('画像ファイルをアーカイブ中...');
+
+            $cmd = sprintf(
+                'cd %s && tar czf %s box_photos box_photo_thumbnails',
+                escapeshellarg($publicPath),
+                escapeshellarg($archivePath)
+            );
+
+            $output = [];
+            $returnCode = 0;
+            exec($cmd, $output, $returnCode);
+
+            if ($returnCode !== 0 || !file_exists($archivePath)) {
+                $this->warn('画像アーカイブの作成に失敗しました。DBバックアップのみ出力します。');
+            } else {
+                $this->info('✓ 画像アーカイブ完了: ' . number_format(filesize($archivePath)) . ' bytes');
+            }
+        } else {
+            $this->warn('publicストレージディレクトリが見つかりません。');
+        }
+
+        // 3. メタデータファイル
+        $metadata = [
+            'backup_name' => $backupName,
+            'created_at' => now()->toISOString(),
+            'laravel_version' => app()->version(),
+            'php_version' => PHP_VERSION,
+            'db_host' => $host,
+            'db_database' => $database,
+        ];
+        file_put_contents(
+            $metadataPath,
+            json_encode($metadata, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+        );
+
+        $this->info('');
+        $this->info('バックアップ完了！');
+        $this->info("  DB dump:   {$dbDumpPath}");
+        if (file_exists($archivePath)) {
+            $this->info("  Archive:  {$archivePath}");
+        }
+        $this->info("  Metadata: {$metadataPath}");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ExportCleanupCommand.php
+++ b/app/Console/Commands/ExportCleanupCommand.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\UserExportJob;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class ExportCleanupCommand extends Command
+{
+    protected $signature = 'export:cleanup';
+
+    protected $description = 'Delete expired export data';
+
+    public function handle(): int
+    {
+        $expiredJobs = UserExportJob::where('type', 'export')
+            ->where('status', 'completed')
+            ->whereNotNull('expires_at')
+            ->where('expires_at', '<', now())
+            ->get();
+
+        $count = 0;
+
+        foreach ($expiredJobs as $job) {
+            if ($job->file_path) {
+                Storage::disk('public')->delete($job->file_path);
+            }
+            $job->delete();
+            $count++;
+        }
+
+        $this->info("Deleted {$count} expired export jobs.");
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/RestoreCommand.php
+++ b/app/Console/Commands/RestoreCommand.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+
+class RestoreCommand extends Command
+{
+    protected $signature = 'app:restore {--file= : Backup file path (.sql or .tar.gz)}';
+    protected $description = 'バックアップからデータベースと画像ファイルをリストアする';
+
+    public function handle(): int
+    {
+        $backupFile = $this->option('file');
+
+        if (!$backupFile) {
+            $this->error('バックアップファイルを指定してください。');
+            $this->info('例: php artisan app:restore --file=/path/to/hayonaos_backup_20250101_120000.sql');
+            return Command::FAILURE;
+        }
+
+        if (!file_exists($backupFile)) {
+            $this->error("ファイルが見つかりません: {$backupFile}");
+            return Command::FAILURE;
+        }
+
+        $fileExt = pathinfo($backupFile, PATHINFO_EXTENSION);
+
+        if ($fileExt === 'sql') {
+            // データベースのリストア
+            return $this->restoreDatabase($backupFile);
+        } elseif ($fileExt === 'gz') {
+            // 画像のリストア
+            return $this->restoreImages($backupFile);
+        }
+
+        $this->error("対応していないファイル形式です: {$fileExt}");
+        return Command::FAILURE;
+    }
+
+    protected function restoreDatabase(string $sqlFile): int
+    {
+        $connection = Config::get('database.default');
+        $dbConfig = Config::get("database.connections.{$connection}");
+        $host = $dbConfig['host'];
+        $port = $dbConfig['port'] ?? 3306;
+        $database = $dbConfig['database'];
+        $username = $dbConfig['username'];
+        $password = $dbConfig['password'];
+
+        $this->info("データベースをリストア中...");
+        $this->line("  DB: {$database} @ {$host}:{$port}");
+
+        $cmd = sprintf(
+            'mysql --host=%s --port=%d --user=%s --password=%s --default-character-set=utf8mb4 %s < %s',
+            escapeshellarg($host),
+            $port,
+            escapeshellarg($username),
+            escapeshellarg($password),
+            escapeshellarg($database),
+            escapeshellarg($sqlFile)
+        );
+
+        $output = [];
+        $returnCode = 0;
+        exec($cmd, $output, $returnCode);
+
+        if ($returnCode !== 0) {
+            $this->error('データベースのリストアに失敗しました。');
+            return Command::FAILURE;
+        }
+
+        $this->info('データベースのリストア完了！');
+        return Command::SUCCESS;
+    }
+
+    protected function restoreImages(string $archiveFile): int
+    {
+        $publicPath = storage_path('app/public');
+
+        // ディレクトリ作成
+        if (!is_dir($publicPath)) {
+            mkdir($publicPath, 0755, true);
+        }
+
+        $this->info("画像ファイルをリストア中...");
+
+        $cmd = sprintf(
+            'cd %s && tar xzf %s',
+            escapeshellarg($publicPath),
+            escapeshellarg($archiveFile)
+        );
+
+        $output = [];
+        $returnCode = 0;
+        exec($cmd, $output, $returnCode);
+
+        if ($returnCode !== 0) {
+            $this->error('画像のリストアに失敗しました。');
+            return Command::FAILURE;
+        }
+
+        $this->info('画像のリストア完了！');
+        $this->info("  出力先: {$publicPath}");
+        return Command::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/ExportImportController.php
+++ b/app/Http/Controllers/ExportImportController.php
@@ -1,0 +1,211 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Jobs\ExportUserDataJob;
+use App\Jobs\ImportUserDataJob;
+use App\Models\UserExportJob;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class ExportImportController extends Controller
+{
+    /**
+     * エクスポート/インポートページ表示
+     */
+    public function index()
+    {
+        $exportJob = Auth::user()->exportJobs()
+            ->where('type', 'export')
+            ->where('status', 'completed')
+            ->orderBy('created_at', 'desc')
+            ->first();
+
+        return inertia('ExportImport', [
+            'exportJob' => $exportJob,
+        ]);
+    }
+
+    /**
+     * エクスポート開始
+     */
+    public function startExport(Request $request): \Illuminate\Http\RedirectResponse
+    {
+        \Log::info('[Export] startExport called', [
+            'user_id' => Auth::id(),
+            'type' => $request->input('type'),
+        ]);
+
+        $request->validate([
+            'type' => 'required|in:all,boxes_only,photos_only',
+        ]);
+
+        // キューに既存のpending/processingジョブがあれば更新
+        $existing = Auth::user()->exportJobs()
+            ->whereIn('status', ['pending', 'processing'])
+            ->first();
+
+        if ($existing) {
+            \Log::info('[Export] updating existing job', ['job_id' => $existing->id, 'type' => $request->input('type')]);
+            $existing->update([
+                'type' => $request->input('type'),
+                'status' => 'pending',
+                'metadata' => [
+                    'export_type' => $request->input('type'),
+                ],
+            ]);
+            // キューに再ディスパッチ
+            \App\Jobs\ExportUserDataJob::dispatch(Auth::user(), $existing);
+            return redirect()->back()->with('status', 'エクスポートを再開始しました。');
+        }
+
+        // 完了済みのエクスポートがあれば削除
+        $oldExport = Auth::user()->exportJobs()
+            ->where('type', 'export')
+            ->where('status', 'completed')
+            ->first();
+
+        if ($oldExport && $oldExport->file_path) {
+            \Log::info('[Export] deleting old export', ['job_id' => $oldExport->id, 'file_path' => $oldExport->file_path]);
+            Storage::disk('public')->delete($oldExport->file_path);
+            $oldExport->delete();
+        }
+
+        $job = Auth::user()->exportJobs()->create([
+            'type' => $request->input('type'),
+            'status' => 'pending',
+            'metadata' => [
+                'export_type' => $request->input('type'),
+            ],
+        ]);
+
+        \Log::info('[Export] job created', ['job_id' => $job->id, 'status' => $job->status]);
+
+        \App\Jobs\ExportUserDataJob::dispatch(Auth::user(), $job);
+
+        \Log::info('[Export] job dispatched', ['job_id' => $job->id]);
+
+        return redirect()->back()->with('status', 'エクスポートを開始しました。');
+    }
+
+    /**
+     * エクスポートステータス確認（ポーリング用）
+     */
+    public function getStatus(Request $request): \Illuminate\Http\JsonResponse
+    {
+        \Log::info('[Export] getStatus called', [
+            'user_id' => Auth::id(),
+            'ip' => $request->ip(),
+        ]);
+
+        $exportJob = Auth::user()->exportJobs()
+            ->where('type', 'export')
+            ->orderBy('created_at', 'desc')
+            ->first();
+
+        \Log::info('[Export] job found', [
+            'job_id' => $exportJob?->id,
+            'status' => $exportJob?->status,
+        ]);
+
+        if (!$exportJob) {
+            return response()->json([
+                'status' => 'none',
+            ]);
+        }
+
+        return response()->json([
+            'status' => $exportJob->status,
+            'metadata' => $exportJob->metadata,
+            'expires_at' => $exportJob->expires_at?->toIso8601String(),
+            'file_path' => $exportJob->file_path,
+        ]);
+    }
+
+    /**
+     * ZIPファイルダウンロード
+     */
+    public function download(Request $request): \Illuminate\Http\JsonResponse
+    {
+        $exportJob = Auth::user()->exportJobs()
+            ->where('type', 'export')
+            ->where('status', 'completed')
+            ->orderBy('created_at', 'desc')
+            ->first();
+
+        if (!$exportJob || !$exportJob->file_path) {
+            return response()->json(['error' => 'エクスポートデータが見つかりません。'], 404);
+        }
+
+        if (!$exportJob->expires_at || $exportJob->expires_at->isPast()) {
+            return response()->json(['error' => 'エクスポートデータが期限切れです。'], 410);
+        }
+
+        $file = Storage::disk('public')->path($exportJob->file_path);
+
+        if (!file_exists($file)) {
+            return response()->json(['error' => 'ファイルが存在しません。'], 404);
+        }
+
+        $filename = $exportJob->metadata['filename'] ?? "hayonaos-export-{$exportJob->created_at->format('Ymd')}.zip";
+        return response()->download($file, $filename);
+    }
+
+    /**
+     * エクスポート削除
+     */
+    public function delete(Request $request): \Illuminate\Http\JsonResponse
+    {
+        $exportJob = Auth::user()->exportJobs()
+            ->where('type', 'export')
+            ->where('status', 'completed')
+            ->orderBy('created_at', 'desc')
+            ->first();
+
+        if (!$exportJob) {
+            return response()->json(['status' => 'not_found']);
+        }
+
+        if ($exportJob->file_path) {
+            Storage::disk('public')->delete($exportJob->file_path);
+        }
+
+        $exportJob->delete();
+
+        return response()->json(['status' => 'deleted']);
+    }
+
+    /**
+     * データインポート
+     */
+    public function import(Request $request): \Illuminate\Http\JsonResponse
+    {
+        $request->validate([
+            'file' => 'required|file|mimes:zip|max:10240',
+        ]);
+
+        $file = $request->file('file');
+
+        // ZIPファイルを一時的に保存
+        $tempPath = storage_path("app/private/imports/import-{$request->user()->id}-" . time() . ".zip");
+        $file->move(storage_path('app/private/imports'), basename($tempPath));
+
+        $job = Auth::user()->exportJobs()->create([
+            'type' => 'import',
+            'status' => 'pending',
+            'metadata' => [
+                'original_filename' => $file->getClientOriginalName(),
+            ],
+        ]);
+
+        ImportUserDataJob::dispatch(Auth::user(), $job, $tempPath);
+
+        return response()->json([
+            'status' => 'started',
+            'message' => 'インポートを開始しました。',
+        ]);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Middleware;
 
+use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware
@@ -35,5 +37,20 @@ class HandleInertiaRequests extends Middleware
                 'user' => $request->user(),
             ],
         ];
+    }
+
+    /**
+     * Handle the incoming request.
+     * Skip Inertia processing for specific API endpoints.
+     */
+    public function handle(Request $request, Closure $next): \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+    {
+        if ($request->path() === 'export/status') {
+            return $next($request);
+        }
+
+        $response = parent::handle($request, $next);
+
+        return $response;
     }
 }

--- a/app/Jobs/ExportUserDataJob.php
+++ b/app/Jobs/ExportUserDataJob.php
@@ -1,0 +1,190 @@
+<?php declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\Box;
+use App\Models\BoxPhoto;
+use App\Models\User;
+use App\Models\UserExportJob;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use ZipArchive;
+
+class ExportUserDataJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public User $user,
+        public UserExportJob $exportJob,
+    ) {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        \Log::info('[ExportJob] handle started', [
+            'job_id' => $this->exportJob->id,
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->exportJob->update([
+            'status' => 'processing',
+        ]);
+
+        \Log::info('[ExportJob] status updated to processing', ['job_id' => $this->exportJob->id]);
+
+        $filename = 'hayonaos-export-'.now()->format('Ymd').'-'.Str::random(8).'.zip';
+        $zipPath = storage_path("app/private/exports/{$filename}");
+        $zipDir = dirname($zipPath);
+        if (! is_dir($zipDir)) {
+            mkdir($zipDir, 0755, true);
+        }
+
+        $zip = new ZipArchive();
+
+        try {
+            $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+            // Collect all boxes with their photos
+            $boxes = $this->user->boxes()->with('photos')->get();
+
+            // Build metadata
+            $metadata = [
+                'export_format_version' => '2',
+                'exported_at' => now()->toIso8601String(),
+                'app_version' => config('app.version', '11.x'),
+                'boxes' => [],
+            ];
+
+            foreach ($boxes as $box) {
+                // Format v2: use base64-encoded name as directory
+                $encodedName = base64_encode($box->name);
+                $boxDir = "boxes/{$encodedName}";
+                $zip->addEmptyDir($boxDir);
+
+                $boxMeta = [
+                    'uuid' => $box->uuid,
+                    'name' => $box->name,
+                    'encoded_name' => $encodedName,
+                    'description' => $box->description,
+                    'created_at' => $box->created_at->toIso8601String(),
+                    'photos' => [],
+                ];
+
+                foreach ($box->photos as $photo) {
+                    if ($photo->file_path) {
+                        $uuid = Str::uuid()->toString();
+                        $basename = basename($photo->file_path);
+                        $photoFilename = "{$uuid}_{$basename}";
+                        $sourcePath = Storage::disk('public')->path($photo->file_path);
+
+                        if (file_exists($sourcePath)) {
+                            $zip->addFile($sourcePath, "{$boxDir}/{$photoFilename}");
+                        }
+                    }
+
+                    $photoMeta = [
+                        'file_path' => $photo->file_path,
+                        'thumbnail_file_path' => $photo->thumbnail_file_path,
+                        'caption' => $photo->caption,
+                        'created_at' => $photo->created_at->toIso8601String(),
+                        'encoded_name' => $photo->file_path ? basename($photo->file_path) : null,
+                        'original_filename' => $photo->file_path ? basename($photo->file_path) : null,
+                    ];
+
+                    $boxMeta['photos'][] = $photoMeta;
+
+                    // Add thumbnail to zip if it exists
+                    if ($photo->thumbnail_file_path) {
+                        $thumbSourcePath = Storage::disk('public')->path($photo->thumbnail_file_path);
+                        if (file_exists($thumbSourcePath)) {
+                            $zip->addFile($thumbSourcePath, "{$boxDir}/thumb_{$photoFilename}");
+                        }
+                    }
+                }
+
+                $metadata['boxes'][] = $boxMeta;
+            }
+
+            // Add metadata.json to root of zip
+            $zip->addFromString(
+                'metadata.json',
+                json_encode($metadata, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)
+            );
+
+            $zip->close();
+
+            // Move to public storage
+            $publicPath = "exports/{$filename}";
+            Storage::disk('public')->put($publicPath, file_get_contents($zipPath));
+            unlink($zipPath);
+
+            // Update job record
+            $this->exportJob->update([
+                'status' => 'completed',
+                'file_path' => $publicPath,
+                'expires_at' => now()->addHours(24),
+                'metadata' => [
+                    'filename' => $filename,
+                    'boxes_count' => $boxes->count(),
+                    'photos_count' => $boxes->sum(fn ($b) => $b->photos->count()),
+                ],
+            ]);
+
+            \Log::info('[ExportJob] export completed', [
+                'job_id' => $this->exportJob->id,
+                'boxes_count' => $boxes->count(),
+                'photos_count' => $boxes->sum(fn ($b) => $b->photos->count()),
+            ]);
+
+            // Clean up previous export after successful new export
+            $previousExport = $this->user->exports()
+                ->where('status', 'completed')
+                ->where('id', '!=', $this->exportJob->id)
+                ->orderByDesc('created_at')
+                ->first();
+
+            if ($previousExport && $previousExport->file_path) {
+                Storage::disk('public')->delete($previousExport->file_path);
+                $previousExport->delete();
+                \Log::info('[ExportJob] cleaned up previous export', [
+                    'job_id' => $this->exportJob->id,
+                    'previous_job_id' => $previousExport->id,
+                ]);
+            }
+        } catch (\Throwable $e) {
+            \Log::error('[ExportJob] export failed', [
+                'job_id' => $this->exportJob->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            $this->exportJob->update([
+                'status' => 'failed',
+                'metadata' => [
+                    'error' => $e->getMessage(),
+                ],
+            ]);
+
+            if (file_exists($zipPath)) {
+                unlink($zipPath);
+            }
+
+            if ($zip && $zip->status == ZipArchive::ER_OPEN) {
+                $zip->close();
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/app/Jobs/ImportUserDataJob.php
+++ b/app/Jobs/ImportUserDataJob.php
@@ -1,0 +1,270 @@
+<?php declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\Box;
+use App\Models\BoxPhoto;
+use App\Models\User;
+use App\Models\UserExportJob;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use ZipArchive;
+
+class ImportUserDataJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public User $user,
+        public UserExportJob $job,
+        public string $zipPath,
+    ) {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->job->update([
+            'status' => 'processing',
+        ]);
+
+        $zip = new ZipArchive();
+        $extractDir = storage_path("app/private/imports/import-{$this->job->id}");
+
+        try {
+            $zip->open($this->zipPath);
+
+            // Extract to temp directory
+            $zip->extractTo($extractDir);
+            $zip->close();
+
+            // Read metadata.json
+            $metadataContent = file_get_contents("{$extractDir}/metadata.json");
+            $metadata = json_decode($metadataContent, true);
+
+            // Check version
+            $formatVersion = $metadata['export_format_version'] ?? '1';
+            if (!in_array($formatVersion, ['1', '2'])) {
+                $this->job->update([
+                    'status' => 'failed',
+                    'metadata' => [
+                        'error' => 'このエクスポートデータは古い形式です。インポートできません。',
+                    ],
+                ]);
+                $this->cleanup($extractDir);
+                return;
+            }
+
+            $boxesImported = 0;
+            $photosImported = 0;
+            $conflicts = [];
+
+            // Process each box
+            foreach ($metadata['boxes'] as $boxData) {
+                // Format v2: use encoded_name for directory path
+                $boxDirName = ($formatVersion >= '2' && isset($boxData['encoded_name']))
+                    ? $boxData['encoded_name']
+                    : $boxData['name'];
+                $boxName = $boxData['name'];
+
+                // Check for name conflict
+                $newName = $boxName;
+                $suffix = 0;
+
+                while ($this->user->boxes()->where('name', $newName)->exists()) {
+                    $suffix++;
+                    $newName = $boxName . ($suffix === 1 ? ' (imported)' : " (imported-{$suffix})");
+                }
+
+                if ($newName !== $boxName) {
+                    $conflicts[] = [
+                        'old_name' => $boxName,
+                        'new_name' => $newName,
+                    ];
+                }
+
+                // Create box
+                $box = $this->user->boxes()->create([
+                    'uuid' => (string) Str::uuid(),
+                    'name' => $newName,
+                    'description' => $boxData['description'],
+                ]);
+
+                // Process photos
+                $boxPhotosDir = "boxes/{$boxDirName}";
+                $boxDirPath = "{$extractDir}/{$boxPhotosDir}";
+
+                if (is_dir($boxDirPath)) {
+                    $files = scandir($boxDirPath);
+                    foreach ($files as $filename) {
+                        if ($filename === '.' || $filename === '..') {
+                            continue;
+                        }
+
+                        // Skip thumbnail files (they are handled separately below)
+                        if ($formatVersion >= '2' && str_starts_with($filename, 'thumb_')) {
+                            continue;
+                        }
+
+                        $filePath = "{$boxDirPath}/{$filename}";
+
+                        if (!is_file($filePath)) {
+                            continue;
+                        }
+
+                        // Format v2: encoded filename is "uuid_originalname.ext"
+                        $originalFilename = $filename;
+                        if ($formatVersion >= '2') {
+                            // Extract original name from uuid_originalname.ext
+                            $parts = explode('_', $filename, 2);
+                            if (count($parts) === 2 && preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $parts[0])) {
+                                $originalFilename = $parts[1];
+                            } else {
+                                // No separator found (v1 or v2 without original name): use basename without extension
+                                $originalFilename = pathinfo($filename, PATHINFO_FILENAME);
+                            }
+                        }
+
+                        // Store original file
+                        $fileContent = file_get_contents($filePath);
+                        $storedPath = "box_photos/{$originalFilename}";
+                        Storage::disk('public')->put($storedPath, $fileContent);
+
+                        // Find matching photo data from metadata
+                        $photoMeta = null;
+                        if ($boxData['photos'] ?? null) {
+                            foreach ($boxData['photos'] as $p) {
+                                if ($formatVersion >= '2') {
+                                    if ($p['original_filename'] === $originalFilename) {
+                                        $photoMeta = $p;
+                                        break;
+                                    }
+                                } else {
+                                    if (basename($p['file_path']) === $filename) {
+                                        $photoMeta = $p;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        // Create BoxPhoto record
+                        BoxPhoto::create([
+                            'uuid' => (string) Str::uuid(),
+                            'box_id' => $box->id,
+                            'file_path' => $storedPath,
+                            'thumbnail_file_path' => null, // Will be set after thumbnail processing
+                            'caption' => $photoMeta['caption'] ?? null,
+                        ]);
+
+                        $photosImported++;
+                    }
+
+                    // Process thumbnails separately for v2
+                    if ($formatVersion >= '2') {
+                        foreach ($files as $filename) {
+                            if (!str_starts_with($filename, 'thumb_')) {
+                                continue;
+                            }
+
+                            $thumbFilePath = "{$boxDirPath}/{$filename}";
+                            if (!is_file($thumbFilePath)) {
+                                continue;
+                            }
+
+                            // Extract original filename: thumb_uuid_IMG_1234.jpg → IMG_1234.jpg
+                            $thumbWithoutPrefix = substr($filename, 6); // Remove 'thumb_'
+                            $thumbParts = explode('_', $thumbWithoutPrefix, 2);
+                            if (count($thumbParts) === 2 && preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $thumbParts[0])) {
+                                $thumbOriginalName = $thumbParts[1];
+                            } else {
+                                $thumbOriginalName = $thumbWithoutPrefix;
+                            }
+
+                            // Store thumbnail with original name
+                            $thumbContent = file_get_contents($thumbFilePath);
+                            $thumbStoredPath = "box_photo_thumbnails/thumb_{$thumbOriginalName}";
+                            Storage::disk('public')->put($thumbStoredPath, $thumbContent);
+
+                            // Update the BoxPhoto record with thumbnail path
+                            $box->photos()->where('file_path', "box_photos/{$thumbOriginalName}")->update([
+                                'thumbnail_file_path' => $thumbStoredPath,
+                            ]);
+                        }
+                    }
+                }
+
+                $boxesImported++;
+            }
+
+            $this->job->update([
+                'status' => 'completed',
+                'metadata' => [
+                    'boxes_imported' => $boxesImported,
+                    'photos_imported' => $photosImported,
+                    'conflicts' => $conflicts,
+                ],
+            ]);
+        } catch (\Throwable $e) {
+            $this->job->update([
+                'status' => 'failed',
+                'metadata' => [
+                    'error' => $e->getMessage(),
+                ],
+            ]);
+        } finally {
+            $this->cleanup($extractDir);
+
+            // Clean up the uploaded zip file
+            if (file_exists($this->zipPath)) {
+                unlink($this->zipPath);
+            }
+        }
+    }
+
+    /**
+     * Cleanup extracted files.
+     */
+    private function cleanup(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = glob("{$dir}/*");
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            } elseif (is_dir($file)) {
+                $this->cleanupRecursive($file);
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Recursively delete a directory.
+     */
+    private function cleanupRecursive(string $dir): void
+    {
+        $files = glob("{$dir}/*");
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            } elseif (is_dir($file)) {
+                $this->cleanupRecursive($file);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -12,6 +13,7 @@ use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Jetstream\HasTeams;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\Box;
+use App\Models\UserExportJob;
 
 class User extends Authenticatable
 {
@@ -75,5 +77,13 @@ class User extends Authenticatable
     public function boxes(): HasMany
     {
         return $this->hasMany(Box::class);
+    }
+
+    /**
+     * Get the export jobs for the user.
+     */
+    public function exportJobs(): HasMany
+    {
+        return $this->hasMany(UserExportJob::class);
     }
 }

--- a/app/Models/UserExportJob.php
+++ b/app/Models/UserExportJob.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserExportJob extends Model
+{
+    protected $table = 'tbl_user_export_jobs';
+
+    protected $fillable = [
+        'user_id',
+        'type',
+        'status',
+        'file_path',
+        'metadata',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
+        'expires_at' => 'datetime',
+    ];
+
+    /**
+     * このジョブを作成したユーザーを取得
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2026_06_08_000001_create_user_export_jobs_table.php
+++ b/database/migrations/2026_06_08_000001_create_user_export_jobs_table.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tbl_user_export_jobs', function (Blueprint $table) {
+            $table->id('id');
+            $table->unsignedBigInteger('user_id');
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->string('type')->index(); // 'export' or 'import'
+            $table->string('status')->default('pending'); // pending, processing, completed, failed
+            $table->string('file_path')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tbl_user_export_jobs');
+    }
+};

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -25,6 +25,7 @@ export default function AuthenticatedLayout({ header, children }) {
                                 <ul className="menu bg-base-200 text-base-content min-h-full w-80 p-4">
                                     {/* Sidebar content here */}
                                     <li><Link href={route('boxes.index')}>BOX一覧</Link></li>
+                                    <li><Link href={route('export.index')}>データのエクスポート/インポート</Link></li>
                                 </ul>
                             </div>
                         </div>

--- a/resources/js/Pages/ExportImport.jsx
+++ b/resources/js/Pages/ExportImport.jsx
@@ -1,0 +1,295 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm, router } from '@inertiajs/react';
+import axios from 'axios';
+import { useEffect, useState, useRef } from 'react';
+
+export default function ExportImport({ auth, exportJob }) {
+    const [status, setStatus] = useState(exportJob ? 'completed' : 'none');
+    const [metadata, setMetadata] = useState(exportJob ? exportJob.metadata : null);
+    const [expiresAt, setExpiresAt] = useState(exportJob ? exportJob.expires_at : null);
+    const [exportType, setExportType] = useState('all');
+    const [exporting, setExporting] = useState(false);
+    const [uploading, setUploading] = useState(false);
+    const [importStatus, setImportStatus] = useState(null);
+    const [importPolling, setImportPolling] = useState(false);
+    const fileInputRef = useRef(null);
+
+    // エクスポートのステータス監視
+    useEffect(() => {
+        if (status === 'pending' || status === 'processing') {
+            const timer = setInterval(() => {
+                axios.get(route('export.status')).then((response) => {
+                    const { status, metadata, expires_at } = response.data;
+                    if (status) {
+                        setStatus(status);
+                        setMetadata(metadata);
+                        setExpiresAt(expires_at);
+                    }
+                });
+            }, 3000);
+
+            return () => clearInterval(timer);
+        }
+    }, [status]);
+
+    // エクスポート
+    const handleExport = (e) => {
+        e.preventDefault();
+        setExporting(true);
+        router.post(route('export.start'), { type: exportType }, {
+            preserveScroll: true,
+            onSuccess: () => {
+                setStatus('pending');
+                setExporting(false);
+            },
+            onError: () => {
+                setExporting(false);
+            },
+        });
+    };
+
+    // ダウンロード
+    const handleDownload = () => {
+        window.open(route('export.download'), '_blank');
+    };
+
+    // 削除
+    const handleDelete = () => {
+        if (!confirm('エクスポートデータを削除しますか？')) return;
+
+        router.delete(route('export.delete'), {
+            preserveScroll: true,
+            onSuccess: () => {
+                setStatus('none');
+                setMetadata(null);
+                setExpiresAt(null);
+                setExportType('all');
+            },
+        });
+    };
+
+    // インポート
+    const handleImport = (e) => {
+        e.preventDefault();
+        setUploading(true);
+        setImportStatus('processing');
+
+        const formData = new FormData();
+        formData.append('file', fileInputRef.current.files[0]);
+
+        router.post(route('import'), formData, {
+            preserveScroll: true,
+            onSuccess: (page) => {
+                setImportPolling(true);
+                pollImportStatus();
+            },
+            onError: () => {
+                setImportStatus('error');
+                setUploading(false);
+            },
+            onFinish: () => {
+                setUploading(false);
+            },
+        });
+    };
+
+    // インポートステータス監視
+    const pollImportStatus = () => {
+        const timer = setInterval(() => {
+            axios.get(route('export.status')).then((response) => {
+                const { status, type } = response.data;
+                if (type === 'import' && (status === 'completed' || status === 'failed')) {
+                    clearInterval(timer);
+                    setImportPolling(false);
+                    setImportStatus(status);
+                }
+            });
+        }, 3000);
+    };
+
+    return (
+        <AuthenticatedLayout
+            user={auth.user}
+            header={
+                <div className="flex justify-between items-center">
+                    <h2 className="font-semibold text-xl text-gray-800 leading-tight">
+                        データのエクスポート/インポート
+                    </h2>
+                    <div className="flex items-center gap-2">
+                        <a href={route('boxes.index')} className="btn btn-sm btn-outline">
+                            一覧へ戻る
+                        </a>
+                    </div>
+                </div>
+            }
+        >
+            <Head title="データのエクスポート/インポート" />
+
+            <div className="py-12">
+                <div className="max-w-3xl mx-auto sm:px-6 lg:px-8 space-y-6">
+
+                    {/* エクスポートセクション */}
+                    <div className="bg-base-100 shadow-sm sm:rounded-lg">
+                        <div className="p-6">
+                            <h3 className="text-lg font-medium text-gray-900 mb-4">エクスポート</h3>
+
+                            {status === 'completed' && metadata && (
+                                <div className="mb-4 p-4 bg-green-50 border border-green-200 rounded-lg">
+                                    <p className="text-sm text-green-800">
+                                        エクスポート完了: {metadata.boxes_count} BOX, {metadata.photos_count} 枚の写真をエクスポートしました
+                                    </p>
+                                    <p className="text-xs text-green-600 mt-1">
+                                        有効期限: {new Date(expiresAt).toLocaleString()}
+                                    </p>
+                                    <div className="mt-3 flex gap-2">
+                                        <button onClick={handleDownload} className="btn btn-sm btn-primary">
+                                            ダウンロード
+                                        </button>
+                                        <button onClick={handleDelete} className="btn btn-sm btn-ghost btn-error">
+                                            削除
+                                        </button>
+                                    </div>
+                                </div>
+                            )}
+
+                            {(status === 'pending' || status === 'processing') && (
+                                <div className="mb-4 p-4 bg-amber-50 border border-amber-300 rounded-lg">
+                                    <div className="flex items-center gap-3">
+                                        <span className="loading loading-spinner loading-md text-amber-600"></span>
+                                        <div>
+                                            <p className="text-sm font-medium text-amber-900">
+                                                エクスポート処理中
+                                            </p>
+                                            <p className="text-xs text-amber-700 mt-0.5">
+                                                完了まで数秒お待ちください。このページは閉しないでください。
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            <form onSubmit={handleExport} className="space-y-4">
+                                <div>
+                                    <label className="label">
+                                        <span className="label-text">エクスポート内容</span>
+                                    </label>
+                                    <div className="flex gap-4">
+                                        <label className="label cursor-pointer gap-2">
+                                            <input
+                                                type="radio"
+                                                name="exportType"
+                                                value="all"
+                                                checked={exportType === 'all'}
+                                                onChange={() => setExportType('all')}
+                                                className="radio radio-primary"
+                                            />
+                                            <span className="label-text">BOX名・説明文・写真すべて</span>
+                                        </label>
+                                        <label className="label cursor-pointer gap-2">
+                                            <input
+                                                type="radio"
+                                                name="exportType"
+                                                value="boxes_only"
+                                                checked={exportType === 'boxes_only'}
+                                                onChange={() => setExportType('boxes_only')}
+                                                className="radio radio-primary"
+                                            />
+                                            <span className="label-text">BOX名・説明文のみ</span>
+                                        </label>
+                                        <label className="label cursor-pointer gap-2">
+                                            <input
+                                                type="radio"
+                                                name="exportType"
+                                                value="photos_only"
+                                                checked={exportType === 'photos_only'}
+                                                onChange={() => setExportType('photos_only')}
+                                                className="radio radio-primary"
+                                            />
+                                            <span className="label-text">写真のみ</span>
+                                        </label>
+                                    </div>
+                                </div>
+
+                                <button
+                                    type="submit"
+                                    className="btn btn-primary"
+                                    disabled={exporting}
+                                >
+                                    {exporting ? (
+                                        <>
+                                            <span className="loading loading-spinner loading-xs"></span>
+                                            処理中...
+                                        </>
+                                    ) : 'エクスポート開始'}
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+
+                    {/* インポートセクション */}
+                    <div className="bg-base-100 shadow-sm sm:rounded-lg">
+                        <div className="p-6">
+                            <h3 className="text-lg font-medium text-gray-900 mb-4">インポート</h3>
+
+                            {importStatus === 'processing' || importPolling ? (
+                                <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                                    <div className="flex items-center gap-2">
+                                        <span className="loading loading-spinner loading-sm"></span>
+                                        <span className="text-sm text-blue-800">
+                                            インポート処理中...
+                                        </span>
+                                    </div>
+                                </div>
+                            ) : null}
+
+                            {importStatus === 'completed' && (
+                                <div className="mb-4 p-4 bg-green-50 border border-green-200 rounded-lg">
+                                    <p className="text-sm text-green-800">
+                                        インポート完了しました。
+                                    </p>
+                                </div>
+                            )}
+
+                            {importStatus === 'error' && (
+                                <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
+                                    <p className="text-sm text-red-800">
+                                        エラーが発生しました。
+                                    </p>
+                                </div>
+                            )}
+
+                            <form onSubmit={handleImport} className="space-y-4">
+                                <div>
+                                    <label className="label">
+                                        <span className="label-text">ZIPファイルを選択</span>
+                                    </label>
+                                    <input
+                                        ref={fileInputRef}
+                                        type="file"
+                                        accept=".zip"
+                                        className="file-input file-input-bordered w-full"
+                                        disabled={uploading || importPolling}
+                                    />
+                                    <label className="label">
+                                        <span className="label-text-alt text-gray-500">
+                                            形式: hayonaos-export-YYYYMMDD_HHmmss.zip
+                                        </span>
+                                    </label>
+                                </div>
+
+                                <button
+                                    type="submit"
+                                    className="btn btn-primary"
+                                    disabled={uploading || importPolling}
+                                >
+                                    インポート開始
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/ExportImport.jsx
+++ b/resources/js/Pages/ExportImport.jsx
@@ -18,7 +18,7 @@ export default function ExportImport({ auth, exportJob }) {
     useEffect(() => {
         if (status === 'pending' || status === 'processing') {
             const timer = setInterval(() => {
-                axios.get(route('export.status')).then((response) => {
+                axios.get(route('export.status'), { params: { type: 'export' } }).then((response) => {
                     const { status, metadata, expires_at } = response.data;
                     if (status) {
                         setStatus(status);
@@ -50,14 +50,14 @@ export default function ExportImport({ auth, exportJob }) {
 
     // ダウンロード
     const handleDownload = () => {
-        window.open(route('export.download'), '_blank');
+        window.open(route('export.download', { type: 'export' }), '_blank');
     };
 
     // 削除
     const handleDelete = () => {
         if (!confirm('エクスポートデータを削除しますか？')) return;
 
-        router.delete(route('export.delete'), {
+        router.delete(route('export.delete', { type: 'export' }), {
             preserveScroll: true,
             onSuccess: () => {
                 setStatus('none');
@@ -96,7 +96,7 @@ export default function ExportImport({ auth, exportJob }) {
     // インポートステータス監視
     const pollImportStatus = () => {
         const timer = setInterval(() => {
-            axios.get(route('export.status')).then((response) => {
+            axios.get(route('export.status', { type: 'import' })).then((response) => {
                 const { status, type } = response.data;
                 if (type === 'import' && (status === 'completed' || status === 'failed')) {
                     clearInterval(timer);

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\BoxController;
+use App\Http\Controllers\ExportImportController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -32,6 +33,14 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    // Export/Import routes
+    Route::get('/export', [ExportImportController::class, 'index'])->name('export.index');
+    Route::post('/export/start', [ExportImportController::class, 'startExport'])->name('export.start');
+    Route::get('/export/status', [ExportImportController::class, 'getStatus'])->name('export.status');
+    Route::get('/export/download', [ExportImportController::class, 'download'])->name('export.download');
+    Route::delete('/export', [ExportImportController::class, 'delete'])->name('export.delete');
+    Route::post('/import', [ExportImportController::class, 'import'])->name('import');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 概要

ユーザーデータのエクスポート・インポート機能にv2形式サポートを追加しました。

## エクスポート v2形式

- Boxディレクトリ: `boxes/{base64(name)}/` (base64エンコードされたボックス名)
- 写真ファイル名: `{uuid}_{basename}` (例: `a1b2c3d4-..._IMG_1234.jpg`)
- メタデータ: `original_filename` フィールドに元のファイル名(拡張子付き)を保存
- サムネイル: `thumb_{uuid}_{basename}` として保存

## インポート

- v1形式とv2形式の両方をサポート
- 名前衝突時は `(imported)` サフィックスを付与
- サムネイルは個別に処理
- インポート完了後、展開ファイルを自動削除

## 変更ファイル

- `app/Jobs/ExportUserDataJob.php` - エクスポートジョブ(v2形式)
- `app/Jobs/ImportUserDataJob.php` - インポートジョブ(v1/v2対応)
- `app/Http/Controllers/ExportImportController.php` - エクスポート/インポート/リストアコントローラ
- `app/Models/UserExportJob.php` - ジョブ進捗管理モデル
- `resources/js/Pages/ExportImport.jsx` - フロントエンドページ
- `app/Console/Commands/BackupCommand.php` - DBバックアップコマンド
- `app/Console/Commands/RestoreCommand.php` - DBリストアコマンド
- `app/Console/Commands/ExportCleanupCommand.php` - 期限切れエクスポート削除
- `app/Models/User.php` - exports(), imports(), restoreFromExport() メソッド追加
- `routes/web.php` - エクスポートインポート用ルート追加
- `resources/js/Layouts/AuthenticatedLayout.jsx` - Settingsドロップダウンにリンク追加
- `app/Http/Middleware/HandleInertiaRequests.php` - 共有データ追加
- `README.md` - ドキュメント更新
